### PR TITLE
Bugfix & Update

### DIFF
--- a/winuiTest/App.cpp
+++ b/winuiTest/App.cpp
@@ -112,7 +112,7 @@ void App::OnSuspending([[maybe_unused]] IInspectable const& sender, [[maybe_unus
 {
     // Save application state and stop any background activity
 
-    delete  CMgrThreads::getMgr();
+    CMgrThreads::shutdown();
 }
 
 /// <summary>

--- a/winuiTest/Job.h
+++ b/winuiTest/Job.h
@@ -7,11 +7,11 @@ namespace winrt::winuiTest::implementation
 	class CJob
 	{
 	public:
-		virtual void	doJob ( ){ }
-		virtual void	showResult ( winrt::hstring& strResult ) { }
+		virtual void doJob() = 0;
+		virtual winrt::hstring showResult() = 0;
 
 		CJob ( );
-		~CJob ( );
+		virtual ~CJob ( );
 
 		bool	m_bDone;
 

--- a/winuiTest/LoopStride.cpp
+++ b/winuiTest/LoopStride.cpp
@@ -83,6 +83,7 @@ void CLoopStride::doJob_2()
 	m_dwCnt_2 = GetTickCount() - m_dwCnt_2;
 
 	m_bDone = true;
+	delete[] memory;
 }
 
 void CLoopStride::doJob_3()

--- a/winuiTest/LoopStride.cpp
+++ b/winuiTest/LoopStride.cpp
@@ -92,15 +92,14 @@ void CLoopStride::doJob_3()
 
 	m_dwCnt_1 = GetTickCount();
 
-	constexpr int iterTimes = 50;
+	constexpr int iterTimes = 100;
 
 	// 逐行遍历
 	for (int t = 0; t < iterTimes; t++)
 	{
-		unsigned sum_row = 0;
 		for (int r = 0; r < row; r++)
 			for (int c = 0; c < col; c++)
-				sum_row += matrix[r][c];
+				matrix[r][c] += r + c;
 	}
 
 	m_dwCnt_2 = GetTickCount();
@@ -109,10 +108,9 @@ void CLoopStride::doJob_3()
 	// 逐列遍历
 	for (int t = 0; t < iterTimes; t++)
 	{
-		unsigned sum_col = 0;
 		for (int c = 0; c < col; c++)
 			for (int r = 0; r < row; r++)
-				sum_col += matrix[r][c];
+				matrix[r][c] += r + c;
 	}
 
 	m_dwCnt_2 = GetTickCount() - m_dwCnt_2;

--- a/winuiTest/LoopStride.cpp
+++ b/winuiTest/LoopStride.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include <algorithm>
 #include "LoopStride.h"
 
 using namespace winrt;
@@ -7,51 +8,67 @@ using namespace winuiTest::implementation;
 
 // https://manybutfinite.com/post/intel-cpu-caches/
 
-void CLoopStride::doJob ( )
+void CLoopStride::doJob()
 {
-	DWORD	dwCnt;
+	if (whichJob == Job_1)
+		doJob_1();
+	else if (whichJob == Job_2)
+		doJob_2();
+	else
+		doJob_3();
+}
 
-	const int LEN	= 64 * 1024 * 1024;
-	int* arr		= new int[LEN];
+CLoopStride::CLoopStride()
+	:whichJob(Job_1), m_dwCnt_1(0), m_dwCnt_2(0) {}
 
-	m_dwCnt_1	= GetTickCount ( );
+CLoopStride::CLoopStride(WhichJob whichJob)
+	: whichJob(whichJob), m_dwCnt_1(0), m_dwCnt_2(0) {}
+
+
+CLoopStride::~CLoopStride()
+{
+}
+
+hstring CLoopStride::showResult()
+{
+	if (whichJob == Job_2)
+		return L"time: " + to_hstring(uint32_t(m_dwCnt_2)) + L" ms";
+	else
+		return L"time1: " + to_hstring(uint32_t(m_dwCnt_1)) + L" ms"
+		+ L"\ntime2: " + to_hstring(uint32_t(m_dwCnt_2)) + L" ms";
+}
+
+void CLoopStride::doJob_1()
+{
+	const int LEN = 64 * 1024 * 1024;
+	unsigned *arr = new unsigned[LEN];
+	std::fill_n(arr, LEN, 1);
+
+	m_dwCnt_1 = GetTickCount();
 
 	for (int i = 0; i < LEN; i += 2) arr[i] *= i;
 
-	m_dwCnt_2	= GetTickCount ( );
-	m_dwCnt_1	= m_dwCnt_2 - m_dwCnt_1;
+	m_dwCnt_2 = GetTickCount();
+	m_dwCnt_1 = m_dwCnt_2 - m_dwCnt_1;
 
 	for (int i = 0; i < LEN; i += 8) arr[i] *= i;
 
-	m_dwCnt_2	= GetTickCount ( ) - m_dwCnt_2;
+	m_dwCnt_2 = GetTickCount() - m_dwCnt_2;
 
-	m_bDone	= true;
-}
-
-CLoopStride::CLoopStride ( )
-{
-}
-
-CLoopStride::~CLoopStride ( )
-{
-}
-
-void CLoopStride::showResult ( winrt::hstring& strResult )
-{
-//	winrt::hstring	str;
-//	std::string	str;
-
-//	strResult	= to_hstring ( m_dwCnt_1 );
-//	strResult	= view;
+	m_bDone = true;
+	delete[] arr;
 }
 
 //#define	size	1, 16, 512, 1024
 // STRIDE from 1 to 16
 #define	STRIDE	4
-void CLoopStride::doJob_2 ( )
+void CLoopStride::doJob_2()
 {
-	int		memory[65535];
-	int		size = 512;
+	constexpr int LEN = 65535;
+	unsigned *memory = new unsigned[LEN];
+	std::fill_n(memory, LEN, 1);
+
+	constexpr int size = 512;
 
 	m_dwCnt_2 = GetTickCount();
 
@@ -68,33 +85,33 @@ void CLoopStride::doJob_2 ( )
 	m_bDone = true;
 }
 
-void CLoopStride::doJob_3 ( )
+void CLoopStride::doJob_3()
 {
-	const int row = 1024;
-	const int col = 512;
-	int matrix[row][col];
-
-	DWORD	dwCnt;
+	std::fill_n(&matrix[0][0], row * col, 1);
 
 	m_dwCnt_1 = GetTickCount();
 
+	constexpr int iterTimes = 50;
+
 	// 逐行遍历
-	int sum_row=0;
-	for (int r = 0; r < row; r++) {
-		for (int c = 0; c < col; c++) {
-			sum_row += matrix[r][c];
-		}
+	for (int t = 0; t < iterTimes; t++)
+	{
+		unsigned sum_row = 0;
+		for (int r = 0; r < row; r++)
+			for (int c = 0; c < col; c++)
+				sum_row += matrix[r][c];
 	}
 
 	m_dwCnt_2 = GetTickCount();
 	m_dwCnt_1 = m_dwCnt_2 - m_dwCnt_1;
 
 	// 逐列遍历
-	int sum_col=0;
-	for (int c = 0; c < col; c++) {
-		for (int r = 0; r < row; r++) {
-			sum_col += matrix[r][c];
-		}
+	for (int t = 0; t < iterTimes; t++)
+	{
+		unsigned sum_col = 0;
+		for (int c = 0; c < col; c++)
+			for (int r = 0; r < row; r++)
+				sum_col += matrix[r][c];
 	}
 
 	m_dwCnt_2 = GetTickCount() - m_dwCnt_2;

--- a/winuiTest/LoopStride.h
+++ b/winuiTest/LoopStride.h
@@ -4,22 +4,41 @@
 namespace winrt::winuiTest::implementation
 {
 
-    // investigate loop stride and cache line
-    class CLoopStride :
-        public CJob
-    {
+	// investigate loop stride and cache line
+	class CLoopStride : public CJob
+	{
 	public:
-		virtual void	doJob ( );
-		virtual void	showResult ( winrt::hstring& strResult );
+		enum WhichJob { Job_1, Job_2, Job_3 };
 
-        void    doJob_2 ( );
-        void    doJob_3 ( );
+		CLoopStride();
 
-        DWORD   m_dwCnt_1;
-        DWORD   m_dwCnt_2;
+		CLoopStride(WhichJob whichJob);
 
-        CLoopStride ( );
-		~CLoopStride ( );
-    };
+		virtual ~CLoopStride() override;
+
+		virtual void doJob() override;
+
+		virtual winrt::hstring showResult() override;
+
+	private:
+		void doJob_1();
+
+		void doJob_2();
+
+		/// <summary>
+		/// Iterate a 1024*512 matrix by row and by column.
+		/// After it finished, m_dwCnt_1 will be the time of iterating by row,
+		/// and m_dwCnt_2 will be the time of iterating by column.
+		/// </summary>
+		void doJob_3();
+
+		const WhichJob whichJob;
+		DWORD   m_dwCnt_1;
+		DWORD   m_dwCnt_2;
+
+		static constexpr int row = 1024;
+		static constexpr int col = 512;
+		unsigned matrix[row][col]; // matrix is used in doJob_3
+	};
 
 }

--- a/winuiTest/MainPage.h
+++ b/winuiTest/MainPage.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include <memory>
 #include "MainPage.g.h"
 #include "BgLabelControl.h"
 
@@ -15,11 +16,10 @@ namespace winrt::winuiTest::implementation
         int32_t MyProperty();
         void MyProperty(int32_t value);
 
-        void myButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
-        void Button2_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& e);
+        void doJobsButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void showResultButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& e);
 
-        CMgrThreads *   m_pMgr;
-        CJob *          m_pJob;
+        std::unique_ptr<CJob> job1, job2, job3;
     };
 }
 

--- a/winuiTest/MainPage.xaml
+++ b/winuiTest/MainPage.xaml
@@ -12,12 +12,14 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
         <local:BgLabelControl Grid.Column="0"
                               Background="Red"
-                              Label="Hello, World!" />
+                              Label="Hello, World!"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"/>
 
         <StackPanel Grid.Column="1"
                     HorizontalAlignment="Center"
@@ -39,7 +41,9 @@
         <TextBlock Grid.Column="2"
                    x:Name="resultTxt"
                    Text="Welcome!"
-                   FontSize="20" />
+                   FontSize="20"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"/>
     </Grid>
 
 </Page>

--- a/winuiTest/MainPage.xaml
+++ b/winuiTest/MainPage.xaml
@@ -1,15 +1,45 @@
-﻿<Page
-    x:Class="winuiTest.MainPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:winuiTest"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+﻿<Page x:Class="winuiTest.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:winuiTest"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-        <Button x:Name="Button2" Click="Button2_Click" Margin="100,100,0,0">Click button2</Button>
-        <local:BgLabelControl x:Name="myLabel" Background="Red" Label="Hello, World!"/>
-    </StackPanel>
+    <Grid HorizontalAlignment="Center"
+          VerticalAlignment="Center"
+          MinWidth="500">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <local:BgLabelControl Grid.Column="0"
+                              Background="Red"
+                              Label="Hello, World!" />
+
+        <StackPanel Grid.Column="1"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+            <Button x:Name="doJobsButton"
+                    Content="run three jobs"
+                    Click="doJobsButton_Click"
+                    Margin="5"
+                    HorizontalAlignment="Center" />
+            <Button x:Name="showResultButton"
+                    Content="show result"
+                    IsEnabled="False"
+                    Click="showResultButton_Click"
+                    Margin="5"
+                    HorizontalAlignment="Center" />
+        </StackPanel>
+
+
+        <TextBlock Grid.Column="2"
+                   x:Name="resultTxt"
+                   Text="Welcome!"
+                   FontSize="20" />
+    </Grid>
+
 </Page>

--- a/winuiTest/MgrThreads.h
+++ b/winuiTest/MgrThreads.h
@@ -1,40 +1,84 @@
 #pragma once
 
+#include <mutex>
 #include "WorkThread.h"
 #include "Job.h"
 
 namespace winrt::winuiTest::implementation
 {
-#define	MAX_NUM_THREADS	32
+	constexpr DWORD MAX_NUM_THREADS = 32;
 
 	typedef class CMgrThreads	MGRTHREADS, * LPMGRTHREADS;
 
 	class CMgrThreads
 	{
 	public:
-		CMgrThreads();
-		~CMgrThreads();
+		// Disable the copy constructor because of singleton mode.
+		CMgrThreads(const CMgrThreads &) = delete;
+		// Disable the assignment operator because of singleton mode.
+		CMgrThreads &operator=(const CMgrThreads &) = delete;
 
-		CRITICAL_SECTION	m_cs;
+		//CRITICAL_SECTION	m_cs;	
 
 		volatile bool	m_bExit;
 
-		static	LPMGRTHREADS	getMgr ( );
-
+		/// <summary>
+		/// Create all threads in the thread pool.
+		/// </summary>
 		void	createAllWorkThreads ( );
 
+		/// <summary>
+		/// Get and remove the job at the head of the job list.
+		/// Return nullptr if the job list is empty.
+		/// </summary>
 		LPJOB	getJob ( );
+
+		/// <summary>
+		/// Append a job to the tail of the job list.
+		/// One of the thread in the thread pool will execute it.
+		/// </summary>
 		void	addJob ( LPJOB pJob );
 
-	protected:
-		DWORD		m_nThreads;	// should not exceed MAX_NUM_THREADS
+		/// <summary>
+		/// Use this factory methord to get the sole instance of CMgrThreads.
+		/// </summary>
+		static LPMGRTHREADS getMgr();
 
+		static void shutdown();
+
+	protected:
+		/// <summary>
+		/// Size of the thread pool, should not exceed MAX_NUM_THREADS.
+		/// </summary>
+		DWORD m_nThreads;
+
+		/// <summary>
+		/// Thread Pool
+		/// </summary>
 		LPWORKTHREAD	m_lstThreads [ MAX_NUM_THREADS ];
 
+		/// <summary>
+		/// Header of job linked list
+		/// </summary>
 		LPJOB	m_lstJob_header;
+
+		/// <summary>
+		/// Tailer of job linked list
+		/// </summary>
 		LPJOB	m_lstJob_tailer;
 
-		static	LPMGRTHREADS	m_pMgrThreads;
+		// Set the constructor to private because of singleton mode.
+		CMgrThreads();
+
+		// If you want to release the sole instance, please call CMgrThreads::shutdown()
+		virtual ~CMgrThreads();
+
+	private:
+		/// <summary>
+		/// Pointer to the sole instance.
+		/// </summary>
+		static LPMGRTHREADS pMgrThreads;
+		static std::mutex mtx;
 	};
 }
 

--- a/winuiTest/WorkThread.cpp
+++ b/winuiTest/WorkThread.cpp
@@ -19,11 +19,9 @@ void CWorkThread::loopWork ( )
 {
 	while ( !m_pMgr->m_bExit )
 	{
-		LPJOB	pJob;
-		
-		pJob	= m_pMgr->getJob ( );
+		LPJOB pJob = m_pMgr->getJob();
 
-		if ( pJob == nullptr )
+		if (pJob == nullptr) // Job list is empty.
 		{
 			::Sleep ( 200 );
 			continue;
@@ -35,11 +33,11 @@ void CWorkThread::loopWork ( )
 	m_bExited	= true;
 }
 
-CWorkThread::CWorkThread ( )
+CWorkThread::CWorkThread(CMgrThreads *m_pMgr)
 {
 	pNext	= nullptr;
 
-	m_pMgr	= CMgrThreads::getMgr ( );
+	this->m_pMgr	= m_pMgr;
 
 	m_bExited	= false;
 

--- a/winuiTest/WorkThread.h
+++ b/winuiTest/WorkThread.h
@@ -10,7 +10,7 @@ namespace winrt::winuiTest::implementation
 	public:
 		void	loopWork ( );
 
-		CWorkThread::CWorkThread ( );
+		CWorkThread::CWorkThread(CMgrThreads *m_pMgr);
 		CWorkThread::~CWorkThread ( );
 
 		HANDLE	m_hThread;


### PR DESCRIPTION
Author: 朱华彬 2018302110372

不太清楚老师希望做出怎样的显示效果，目前我做到的效果是：

- 点击“run three jobs”按钮，使用线程池 `CMgrThreads` 并发地执行三个计算任务（`CLoopStride` 中的三个 Job 函数）。
- 点击“show result”按钮，把三个计算任务的时间显示出来。

![pic](https://s1.ax1x.com/2020/10/08/0BMqQ1.png)

改动幅度略大，以下为主要的修改内容：

1. 把 `CMgrThreads` 类改成了线程安全的。
1. 修正了 `CMgrThreads` 中的错误，现在 `createAllWorkThreads()` 可以在单例对象创建时自动执行，而无需在外部手动调用。
1. 编写一个静态成员函数 `CMgrThreads::shutdown` 来释放单例对象。原来的方式是 delete 指向单例对象的指针，但是这样很容易不小心对同一对象 delete 多次，故作此修改。
1. 使用 C++ 标准库中的 `std::mutex` 和 `std::lock_guard` 替代原来的 Win32 `CRITICAL_SECTION`，利用 RAII 机制自动加锁、解锁。
1. 修正了几处内存泄漏的 BUG。
1. 修正了几处 undefined behavior。
1. 修正了点击按钮时的一些逻辑错误。
